### PR TITLE
chore: remove parent pom depdendencies, which break maven consumers

### DIFF
--- a/complete-units/build.gradle
+++ b/complete-units/build.gradle
@@ -44,8 +44,6 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
-    compile 'systems.uom:systems-parent:0.7.2'
-
     compile 'systems.uom:systems-quantity:0.7.2'
 
     compile 'systems.uom:systems-common-java8:0.7.2'

--- a/si-units/build.gradle
+++ b/si-units/build.gradle
@@ -45,8 +45,6 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jre8:$kotlin_version"
 
-    compile 'si.uom:si-parent:0.7.1'
-
     compile 'si.uom:si-units-java8:0.7.1'
 
     compile 'si.uom:si-quantity:0.7.1'


### PR DESCRIPTION
The way Physikal is currently packaged on maven central, the pom e.g. of `si-units-1.1.1.0` currently includes: 

```xml
    <dependency>
      <groupId>si.uom</groupId>
      <artifactId>si-parent</artifactId>
      <version>0.7.1</version>
      <scope>compile</scope>
    </dependency>
```

This breaks consumers of Physikal using maven to build: 

```
[ERROR] Failed to execute goal on project model-nosql: Could not resolve dependencies for project de.xxx.core:model-nosql:jar:0.9: The following artifacts could not be resolved: systems.uom:systems-parent:jar:0.7.2, si.uom:si-parent:jar:0.7.1: Failure to find systems.uom:systems-parent:jar:0.7.2 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced -> [Help 1]
``` 

I think the situation si somewhat similar to https://stackoverflow.com/questions/27110014/could-not-find-artifact-in-maven-central-repo-when-search-returns-a-match

In any case, I believe the parent pom is not necessary as a direct dependency. I confirm I can build and consume phyiskal to my local repo just fine using the change in this PR. 