### PR TITLE
Upgraded to Indriya 1.0

### DIFF
--- a/complete-units/build.gradle
+++ b/complete-units/build.gradle
@@ -41,13 +41,13 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compile 'systems.uom:systems-quantity:0.8'
+    compile 'systems.uom:systems-quantity:0.9'
 
-    compile 'systems.uom:systems-common-java8:0.8'
+    compile 'systems.uom:systems-common:0.9'
 
-    compile 'systems.uom:systems-unicode-java8:0.8'
+    compile 'systems.uom:systems-unicode:0.9'
 
-    compile 'systems.uom:systems-ucum-java8:0.8'
+    compile 'systems.uom:systems-ucum:0.9'
 
     compile project(":si-units")
 }

--- a/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Cgs.kt
+++ b/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Cgs.kt
@@ -28,8 +28,8 @@ import org.tenkiv.physikal.core.invoke
 import si.uom.quantity.DynamicViscosity
 import si.uom.quantity.KinematicViscosity
 import systems.uom.common.CGS.*
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.quantity.*
 
 /**

--- a/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Imperial.kt
+++ b/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Imperial.kt
@@ -24,8 +24,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 package org.tenkiv.physikal.complete
 
 import systems.uom.ucum.UCUM
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.quantity.Temperature
 
 /**

--- a/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Ucum.kt
+++ b/complete-units/src/main/kotlin/org/tenkiv/physikal/complete/Ucum.kt
@@ -29,8 +29,8 @@ import si.uom.quantity.*
 import systems.uom.quantity.*
 import systems.uom.quantity.Level
 import systems.uom.ucum.UCUM.*
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.quantity.*
 
 /**

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -41,7 +41,7 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
-    compile 'tec.uom:uom-se:1.0.9'
+    compile 'tec.units:indriya:1.0'
 
     compile 'org.tenkiv.coral.jdk:core:1.0.1.1'
 

--- a/core/src/main/kotlin/org/tenkiv/physikal/core/Collections.kt
+++ b/core/src/main/kotlin/org/tenkiv/physikal/core/Collections.kt
@@ -23,8 +23,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.tenkiv.physikal.core
 
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.unit.Units
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.unit.Units
 import javax.measure.Quantity
 
 /**

--- a/core/src/main/kotlin/org/tenkiv/physikal/core/CoreUnits.kt
+++ b/core/src/main/kotlin/org/tenkiv/physikal/core/CoreUnits.kt
@@ -23,9 +23,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.tenkiv.physikal.core
 
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
-import tec.uom.se.unit.Units.*
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
+import tec.units.indriya.unit.Units.*
 import javax.measure.quantity.*
 
 /**

--- a/core/src/main/kotlin/org/tenkiv/physikal/core/MetricPrefixes.kt
+++ b/core/src/main/kotlin/org/tenkiv/physikal/core/MetricPrefixes.kt
@@ -23,138 +23,138 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.tenkiv.physikal.core
 
-import tec.uom.se.unit.MetricPrefix.*
+import tec.units.indriya.unit.MetricPrefix.*
 
 // All builtin prefixes
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.ZETTA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.ZETTA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.zetta get() = MetricPrefixedNumber(this, ZETTA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.EXA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.EXA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.exa get() = MetricPrefixedNumber(this, EXA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.PETA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.PETA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.peta get() = MetricPrefixedNumber(this, PETA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.TERA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.TERA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.tera get() = MetricPrefixedNumber(this, TERA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.GIGA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.GIGA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.giga get() = MetricPrefixedNumber(this, GIGA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.MEGA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.MEGA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.mega get() = MetricPrefixedNumber(this, MEGA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.KILO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.KILO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.kilo get() = MetricPrefixedNumber(this, KILO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.HECTO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.HECTO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.hecto get() = MetricPrefixedNumber(this, HECTO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.DEKA].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.DEKA].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.deka get() = MetricPrefixedNumber(this, DEKA)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.DECI].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.DECI].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.deci get() = MetricPrefixedNumber(this, DECI)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.CENTI].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.CENTI].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.centi get() = MetricPrefixedNumber(this, CENTI)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.MILLI].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.MILLI].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.milli get() = MetricPrefixedNumber(this, MILLI)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.MICRO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.MICRO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.micro get() = MetricPrefixedNumber(this, MICRO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.NANO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.NANO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.nano get() = MetricPrefixedNumber(this, NANO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.PICO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.PICO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.pico get() = MetricPrefixedNumber(this, PICO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.FEMTO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.FEMTO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.femto get() = MetricPrefixedNumber(this, FEMTO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.ATTO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.ATTO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.atto get() = MetricPrefixedNumber(this, ATTO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.ZEPTO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.ZEPTO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.zepto get() = MetricPrefixedNumber(this, ZEPTO)
 
 /**
- * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.uom.se.unit.MetricPrefix.YOCTO].
+ * Creates a [MetricPrefixedNumber] for creating [javax.measure.Quantity] with [tec.units.indriya.unit.MetricPrefix.YOCTO].
  *
- * @return [MetricPrefixedNumber] with specified [tec.uom.se.unit.MetricPrefix].
+ * @return [MetricPrefixedNumber] with specified [tec.units.indriya.unit.MetricPrefix].
  */
 val Number.yocto get() = MetricPrefixedNumber(this, YOCTO)

--- a/core/src/main/kotlin/org/tenkiv/physikal/core/Operators.kt
+++ b/core/src/main/kotlin/org/tenkiv/physikal/core/Operators.kt
@@ -23,8 +23,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.tenkiv.physikal.core
 
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.Quantity
 import javax.measure.Unit
 
@@ -303,8 +303,8 @@ fun <Q : Quantity<Q>> ComparableQuantity<Q>.abs(): ComparableQuantity<Q> = if (t
  * Checks if the physical quantity represented by two Quantity objects is the same.
  * qeq stands for 'quantity equality'
  */
-infix fun <Q : Quantity<Q>> ComparableQuantity<Q>.qeq(comparate: Quantity<Q>): Boolean = isEquivalentTo(comparate)
-
+infix fun <Q : Quantity<Q>> ComparableQuantity<Q>.qeq(comparate: Quantity<Q>): Boolean = isEquivalentOf(comparate)
+// FIXME this should be isEquivalentTo again after Indriya 1.2
 /**
  * Checks if two [Quantity]s are approximately equal to each other.
  *

--- a/core/src/main/kotlin/org/tenkiv/physikal/core/Type.kt
+++ b/core/src/main/kotlin/org/tenkiv/physikal/core/Type.kt
@@ -23,8 +23,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.tenkiv.physikal.core
 
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.unit.MetricPrefix
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.unit.MetricPrefix
 import javax.measure.Quantity
 import javax.measure.Unit
 

--- a/core/src/test/kotlin/org/tenkiv/physikal/core/CollectionsSpec.kt
+++ b/core/src/test/kotlin/org/tenkiv/physikal/core/CollectionsSpec.kt
@@ -3,7 +3,7 @@ package org.tenkiv.physikal.core
 import io.kotlintest.shouldBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
-import tec.uom.se.ComparableQuantity
+import tec.units.indriya.ComparableQuantity
 import javax.measure.quantity.Pressure
 
 class CollectionsSpec : StringSpec({

--- a/core/src/test/kotlin/org/tenkiv/physikal/core/TypeSpec.kt
+++ b/core/src/test/kotlin/org/tenkiv/physikal/core/TypeSpec.kt
@@ -2,7 +2,7 @@ package org.tenkiv.physikal.core
 
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
-import tec.uom.se.unit.Units
+import tec.units.indriya.unit.Units
 import javax.measure.quantity.Power
 import javax.measure.quantity.Pressure
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=org.tenkiv.physikal
-version=1.1.3.5
+version=1.1.4.0
 
 POM_PACKAGING=jar
 POM_DESCRIPTION=Exension library to aid in unit conversion and handling.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Jun 19 02:05:13 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/si-units/src/main/kotlin/org/tenkiv/physikal/si/Non-SiUnits.kt
+++ b/si-units/src/main/kotlin/org/tenkiv/physikal/si/Non-SiUnits.kt
@@ -27,8 +27,8 @@ import org.tenkiv.physikal.core.MetricPrefixedNumber
 import org.tenkiv.physikal.core.invoke
 import si.uom.NonSI.*
 import si.uom.quantity.IonizingRadiation
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.quantity.*
 
 //For some reason There are public Non-SI Units are included in the SI-Units library,

--- a/si-units/src/main/kotlin/org/tenkiv/physikal/si/SiUnits.kt
+++ b/si-units/src/main/kotlin/org/tenkiv/physikal/si/SiUnits.kt
@@ -28,8 +28,8 @@ import org.tenkiv.physikal.core.invoke
 import si.uom.NonSI.TONNE
 import si.uom.SI.*
 import si.uom.quantity.*
-import tec.uom.se.ComparableQuantity
-import tec.uom.se.quantity.Quantities
+import tec.units.indriya.ComparableQuantity
+import tec.units.indriya.quantity.Quantities
 import javax.measure.quantity.*
 
 /**


### PR DESCRIPTION
When I prepared my KUG talk and ran Scratch files for each of the README examples, I stumbled across problems with uom-systems dependencies and underlying calls. Not sure, why it did not show in the build, but some of them only seem to occur at runtime.
As 0.9 of both si-units and all uom-systems was released on top of Indriya 1.0 I migrated everything to the Indriya version (still JSR 363)

I proposed a new version `1.1.4.0`.